### PR TITLE
Textbox cursor alignment fix

### DIFF
--- a/src/fidgetty/fidget_dev/patches/textboxes.nim
+++ b/src/fidgetty/fidget_dev/patches/textboxes.nim
@@ -185,6 +185,11 @@ proc locationRect*[T](textBox: TextBox[T], loc: int): Rect =
     else:
       let g = layout[loc]
       result = g.selectRect
+  else:
+    # No characters, should be in the middle of the textbox,
+    # not on the left side on the border.
+    result.x = textbox.width / 2
+    result.y = (textbox.height / 2) - (textBox.font.lineHeight / 2)
   result.w = textBox.cursorWidth
   # result.h = min(textBox.font.size, textBox.font.lineHeight)
   let cusorHFactor = textBox.cursorFactors[1]


### PR DESCRIPTION
Fix for the textbox cursor position to the center of the textbox when there is no text in the textbox.